### PR TITLE
Implement wish tracking and Djinn UI

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -1,23 +1,66 @@
 import { useState, useEffect, useRef } from 'react';
 import ResultBlock from './ResultBlock';
+import DjinnIllustration from './DjinnIllustration';
 
 export default function App() {
   const [input, setInput] = useState('');
   const [history, setHistory] = useState<{ question: string; answer: string }[]>([]);
   const [loading, setLoading] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+  const [wishes, setWishes] = useState(3);
+  const [placeholder, setPlaceholder] = useState('Posez votre question...');
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [history, loading]);
 
+  useEffect(() => {
+    const suggestions = [
+      'Quelle est la tendance du Bitcoin ?',
+      'Le Nasdaq va-t-il monter ?',
+      'ETH va dépasser 3000$ ?'
+    ];
+    setPlaceholder(
+      suggestions[Math.floor(Math.random() * suggestions.length)]
+    );
+
+    const today = new Date().toISOString().split('T')[0];
+    const storedDate = localStorage.getItem('nostradamus-date');
+    let remaining = 3;
+    if (storedDate === today) {
+      const saved = parseInt(
+        localStorage.getItem('nostradamus-wishes') || '3',
+        10
+      );
+      remaining = isNaN(saved) ? 3 : saved;
+    } else {
+      localStorage.setItem('nostradamus-date', today);
+    }
+    setWishes(remaining);
+    inputRef.current?.focus();
+  }, []);
+
   const ask = async () => {
     if (!input.trim()) return;
+    if (wishes <= 0) {
+      setHistory((h) => [
+        ...h,
+        { question: input, answer: "Tu n'as plus de vœux pour aujourd'hui." }
+      ]);
+      setInput('');
+      return;
+    }
     const question = input;
     setInput('');
     setLoading(true);
     setHistory((h) => [...h, { question, answer: '' }]);
+    const today = new Date().toISOString().split('T')[0];
+    const newCount = wishes - 1;
+    setWishes(newCount);
+    localStorage.setItem('nostradamus-wishes', newCount.toString());
+    localStorage.setItem('nostradamus-date', today);
     try {
       const res = await fetch('/api/ask', {
         method: 'POST',
@@ -48,7 +91,11 @@ export default function App() {
         <button className="text-sm" onClick={() => setShowHistory(!showHistory)}>Historique</button>
       </nav>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 flex flex-col items-center">
+        <DjinnIllustration wishes={wishes} />
+        {wishes <= 0 && (
+          <p className="text-sm text-red-600">Vous avez épuisé vos vœux pour aujourd'hui.</p>
+        )}
         {history.map((msg, i) => (
           <div key={i} className="space-y-2">
             <div className="flex justify-end">
@@ -69,11 +116,12 @@ export default function App() {
 
       <div className="p-4 border-t border-gray-200 dark:border-gray-700 flex sticky bottom-0 bg-gray-100 dark:bg-[#343541]">
         <textarea
+          ref={inputRef}
           className="flex-1 rounded-md border border-gray-300 dark:border-gray-600 p-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
           rows={2}
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="Posez votre question..."
+          placeholder={placeholder}
         />
         <button
           onClick={ask}


### PR DESCRIPTION
## Summary
- add Djinn illustration to main app
- implement localStorage-based daily wish quota
- auto-focus the textarea and provide random placeholders
- enforce quota on the backend calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68628f4f85c4832393be17cb00c97804